### PR TITLE
agent: speed up trimming of logged lines

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -283,7 +283,17 @@ func (r *runner) run(ctx context.Context) error {
 		// We want the end of the logs, not the beginning
 		logLines := logstream.Lines()
 		fileData, _ := json.Marshal(logLines)
-		for firstLine := 1; len(fileData) > maxLogsUpload; firstLine++ {
+		fileBuffer := bytes.NewBuffer(fileData)
+		suffixBytes := []byte("\\\"},")
+		var firstLine uint = 0
+		for ; fileBuffer.Len() > maxLogsUpload; firstLine++ {
+			// read bytes until we find '"},' in the encoded JSON
+			for c, _ := fileBuffer.ReadBytes(','); bytes.HasSuffix(c, suffixBytes) || !bytes.HasSuffix(c, suffixBytes[1:]); {
+				c, _ = fileBuffer.ReadBytes(',')
+			}
+		}
+		fileData, _ = json.Marshal(logLines[firstLine:])
+		for ; len(fileData) > maxLogsUpload; firstLine++ {
 			fileData, _ = json.Marshal(logLines[firstLine:])
 		}
 


### PR DESCRIPTION
Scanning through a buffer should be much faster
than encoding JSON every time through the loop.

Looking for '"},' isn't a perfect approximation of the next line,
but it should be good enough to keep us synchronized.

This should reduce the calls to json.Marsal on a large array
of lines quite considerably.

